### PR TITLE
Propagate SMM types and resolve SMM protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+__pycache__

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ _A Binary Ninja plugin that automatically resolves type information for EFI prot
 
 ## Description:
 
-EFI Resolver is a Binary Ninja plugin that automates the task of resolving EFI protocol type information. It propagates pointers to system table, boot services, and runtime services to any global variables where they are stored. The plugin also identifies references to the boot services protocol functions and applies type information according to the GUID passed to these functions. The plugin supports all of the core UEFI specification, but does not support vendor protocols.
-
+EFI Resolver is a Binary Ninja plugin that automates the task of resolving EFI protocol type information. It propagates pointers to system table, boot services, runtime services, and SMM/MM system table to any global variables where they are stored. The plugin also identifies references to the boot services and SMM/MM protocol functions and applies type information according to the GUID passed to these functions. The plugin supports all of the core UEFI specification, but does not support vendor protocols.
 
 ## Installation Instructions
 
@@ -28,13 +27,9 @@ This plugin requires the following minimum version of Binary Ninja:
 
 * 4333
 
-
-
 ## Required Dependencies
 
 The following dependencies are required for this plugin:
-
-
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 from binaryninja import PluginCommand, BinaryView, BackgroundTaskThread, log_alert
+from .moduletype import identify_efi_module_type, set_efi_module_entry_type, EFIModuleType
 from .protocols import (
     init_protocol_mapping,
     define_handle_protocol_types,
@@ -20,34 +21,26 @@ def resolve_efi(bv: BinaryView):
             super().__init__("Initializing EFI protocol mappings...", True)
             self.bv = bv
 
-        def run(self):
-            if not init_protocol_mapping():
+        def _resolve_dxe(self):
+            self.progress = "Propagating EFI system table pointers..."
+            if not propagate_system_table_pointers(self.bv, self):
                 return
 
-            if "EFI_SYSTEM_TABLE" not in self.bv.types:
-                log_alert("This binary is not using the EFI platform. Use Open with Options when loading the binary to select the EFI platform.")
+            self.progress = "Defining types for uses of HandleProtocol..."
+            if not define_handle_protocol_types(self.bv, self):
                 return
 
-            self.bv.begin_undo_actions()
-            try:
-                self.progress = "Propagating EFI system table pointers..."
-                if not propagate_system_table_pointers(self.bv, self):
-                    return
+            self.progress = "Defining types for uses of OpenProtocol..."
+            if not define_open_protocol_types(self.bv, self):
+                return
 
-                self.progress = "Defining types for uses of HandleProtocol..."
-                if not define_handle_protocol_types(self.bv, self):
-                    return
+            self.progress = "Defining types for uses of LocateProtocol..."
+            if not define_locate_protocol_types(self.bv, self):
+                return
 
-                self.progress = "Defining types for uses of OpenProtocol..."
-                if not define_open_protocol_types(self.bv, self):
-                    return
-
-                self.progress = "Defining types for uses of LocateProtocol..."
-                if not define_locate_protocol_types(self.bv, self):
-                    return
-
-                # SMM/MM types cannot be propagated until EFI_BOOT_SERVICES types are propagated and the
-                # EFI_MM_BASE_PROTOCOL or EFI_SMM_BASE2_PROTOCOL is resolved
+            # SMM/MM types cannot be propagated until EFI_BOOT_SERVICES types are propagated and the
+            # EFI_MM_BASE_PROTOCOL or EFI_SMM_BASE2_PROTOCOL is resolved
+            if "EFI_MM_SYSTEM_TABLE" in self.bv.types:
                 self.progress = "Defining types for SMM/MM system tables..."
                 if not define_locate_mm_system_table_types(self.bv, self) or not define_locate_smm_system_table_types(
                     self.bv, self
@@ -65,6 +58,32 @@ def resolve_efi(bv: BinaryView):
                     self.bv, self
                 ):
                     return
+
+        def run(self):
+            if not init_protocol_mapping():
+                return
+
+            if "EFI_SYSTEM_TABLE" not in self.bv.types:
+                log_alert("This binary is not using the EFI platform. Use Open with Options when loading the binary to select the EFI platform.")
+                return
+
+            module_type = identify_efi_module_type(self.bv)
+            if module_type == EFIModuleType.UNKNOWN:
+                log_alert("Could not identify the EFI module type.")
+                return
+
+            self.bv.begin_undo_actions()
+            try:
+                try:
+                    set_efi_module_entry_type(self.bv, module_type)
+                except SyntaxError:
+                    log_alert("Failed to set entry function type. Update Binary Ninja for latest EFI type definitions.")
+                    return
+
+                if module_type == EFIModuleType.DXE:
+                    self._resolve_dxe()
+                elif module_type == EFIModuleType.PEI:
+                    log_alert("TE PEI modules are not yet supported.")
             finally:
                 self.bv.commit_undo_actions()
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,11 @@
 from binaryninja import PluginCommand, BinaryView, BackgroundTaskThread, log_alert
-from .protocols import init_protocol_mapping, define_handle_protocol_types, define_open_protocol_types, define_locate_protocol_types
+from .protocols import (
+    init_protocol_mapping,
+    define_handle_protocol_types,
+    define_open_protocol_types,
+    define_locate_protocol_types,
+    define_locate_mm_system_table_types,
+)
 from .system_table import propagate_system_table_pointer
 
 def resolve_efi(bv: BinaryView):
@@ -32,6 +38,10 @@ def resolve_efi(bv: BinaryView):
 
                 self.progress = "Defining types for uses of LocateProtocol..."
                 if not define_locate_protocol_types(self.bv, self):
+                    return
+
+                self.progress = "Defining types for SMM/MM system tables..."
+                if not define_locate_mm_system_table_types(self.bv, self):
                     return
             finally:
                 self.bv.commit_undo_actions()

--- a/moduletype.py
+++ b/moduletype.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from binaryninja import BinaryView, SymbolType
+
+
+class EFIModuleType(Enum):
+    """UEFI module types"""
+
+    UNKNOWN = 0
+    DXE = 1
+    PEI = 2
+
+
+def set_efi_module_entry_type(bv: BinaryView, modtype: EFIModuleType) -> None:
+    """Set the prototype for the module entrypoint"""
+
+    _start = bv.get_symbol_by_raw_name("_start")
+    if not _start or _start.type != SymbolType.FunctionSymbol:
+        return
+
+    func = bv.get_function_at(_start.address)
+    if not func:
+        return
+
+    if modtype == EFIModuleType.PEI:
+        func.type = "EFI_STATUS _start(EFI_PEI_FILE_HANDLE FileHandle, EFI_PEI_SERVICES **PeiServices)"
+
+    if modtype == EFIModuleType.DXE:
+        func.type = "EFI_STATUS _start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemTable)"
+
+    func.reanalyze()
+
+
+def identify_efi_module_type(bv: BinaryView) -> EFIModuleType:
+    """Identify the type of EFI module
+
+    PE's are reported as DXE modules and TE's are reported as PEI modules. This is correct for most
+    cases, and is the convention used by most UEFI tooling.
+    """
+
+    if bv.get_view_of_type("PE"):
+        return EFIModuleType.DXE
+
+    if bv.get_view_of_type("TE"):
+        return EFIModuleType.PEI
+
+    return EFIModuleType.UNKNOWN

--- a/protocols.py
+++ b/protocols.py
@@ -257,7 +257,6 @@ def define_system_table_types_for_refs(
     var_name: str,
     task: BackgroundTask,
 ) -> bool:
-    print(type(refs))
     for ref in list(refs):
         if task.cancelled:
             return False

--- a/system_table.py
+++ b/system_table.py
@@ -86,7 +86,7 @@ def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, fu
 
     return updates
 
-def propagate_system_table_pointer(bv: BinaryView, task: BackgroundTask):
+def propagate_system_table_pointers(bv: BinaryView, task: BackgroundTask):
     # Add entry function to the list of functions in which to propagate.
     func_queue = []
     entry_func = bv.entry_function

--- a/system_table.py
+++ b/system_table.py
@@ -1,7 +1,7 @@
 from binaryninja import (BinaryView, BackgroundTask, PointerType, NamedTypeReferenceType, HighLevelILCallSsa,
                          SSAVariable, Constant, HighLevelILAssign, HighLevelILAssignMemSsa, HighLevelILDerefSsa,
-                         Function, Variable, HighLevelILDerefFieldSsa, HighLevelILVarInitSsa, HighLevelILVarSsa,
-                         StructureType, log_info, log_warn)
+                         Function, HighLevelILDerefFieldSsa, HighLevelILVarInitSsa, HighLevelILVarSsa,
+                         StructureType, log_info, HighLevelILOperation)
 from typing import List
 
 types_to_propagate = ["EFI_SYSTEM_TABLE", "EFI_RUNTIME_SERVICES", "EFI_BOOT_SERVICES"]
@@ -14,7 +14,7 @@ def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, fu
 
     for use in func.hlil.ssa_form.get_ssa_var_uses(var):
         instr = use.parent
-        if isinstance(instr, HighLevelILCallSsa):
+        if isinstance(instr, HighLevelILCallSsa) or instr.operation == HighLevelILOperation.HLIL_TAILCALL:
             # Function call, propagate the variable type to the function call target
             target = instr.dest
             if not isinstance(target, Constant):


### PR DESCRIPTION
This PR propagates the SMM System Table to global variables and resolves SMM/MM protocol interfaces from calls to `MMSystemTable->MmLocateProtocol`, `MMsystemTable->MmHandleProtocol`, etc. It also contains a bug fix for an unhandled exception that occurs on re-runs.

I have also updated the `plugin.json` and README in prep for a v1.1.0 release.

Closes #1
Closes #2 
Closes #3 
Closes #5