### PR TITLE
Propagate more types and use DataRender to display EFI_GUID

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ from .protocols import (
 )
 
 from .system_table import propagate_system_table_pointers
+from .guid_renderer import EfiGuidDataRenderer
 
 def resolve_efi(bv: BinaryView):
     class Task(BackgroundTaskThread):
@@ -73,6 +74,7 @@ def resolve_efi(bv: BinaryView):
                 return
 
             self.bv.begin_undo_actions()
+            EfiGuidDataRenderer().register_type_specific()
             try:
                 try:
                     set_efi_module_entry_type(self.bv, module_type)

--- a/guid_renderer.py
+++ b/guid_renderer.py
@@ -1,0 +1,31 @@
+from binaryninja import DataRenderer, DisassemblyTextLine, InstructionTextToken, InstructionTextTokenType, BinaryReader
+
+
+class EfiGuidDataRenderer(DataRenderer):
+    """
+    DataRenderer for displaying EFI_GUID in a more human-readable manner.
+    """
+    def __init__(self):
+        DataRenderer.__init__(self)
+
+    def perform_is_valid_for_data(self, ctxt, view, addr, typ, context):
+        return DataRenderer.is_type_of_struct_name(typ, "EFI_GUID", context)
+
+    def perform_get_lines_for_data(self, ctxt, view, addr, typ, prefix, width, context):
+        result = [DisassemblyTextLine(prefix, addr)]
+        reader = BinaryReader(view)
+        reader.seek(addr)
+        data1 = reader.read32()
+        data2 = reader.read16()
+        data3 = reader.read16()
+        data4 = reader.read64be()
+        guid_str = f"{data1:08x}-{data2:04x}-{data3:04x}-{data4:016x}"
+        tokens = [InstructionTextToken(InstructionTextTokenType.TextToken, "  [EFI_GUID(\""),
+                  InstructionTextToken(InstructionTextTokenType.StringToken, guid_str),
+                  InstructionTextToken(InstructionTextTokenType.TextToken, "\")]")]
+
+        result.append(DisassemblyTextLine(tokens, addr))
+        return result
+
+    def __del__(self):
+        pass

--- a/system_table.py
+++ b/system_table.py
@@ -10,14 +10,19 @@ types_to_propagate = {
     "EFI_BOOT_SERVICES": "BootServices",
     "EFI_MM_SYSTEM_TABLE": "MmSystemTable",
     "EFI_SMM_SYSTEM_TABLE2": "SmmSystemTable",
+    "EFI_HANDLE": "GlobalHandle",
 }
 
+
 def get_type_name(typ):
-    # When re-running, some types do not have a registered name (causing an exception on typ.name)
+    if isinstance(typ, PointerType):
+        if isinstance(typ.target, NamedTypeReferenceType):
+            return typ.target.name
+        return str(typ.target).split(" ")[-1]
+
     if isinstance(typ, NamedTypeReferenceType):
         return typ.name
 
-    return str(typ).split(" ")[-1]
 
 def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, func_queue: List[Function]) -> bool:
     global types_to_propagate
@@ -36,12 +41,12 @@ def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, fu
 
             for param_idx in range(len(instr.params)):
                 if instr.params[param_idx] == use:
-                    type_name = get_type_name(var.type.target)
-                    log_info(f"Propagating {type_name} pointer to parameter #{param_idx + 1} of {target.name}")
+                    type_name = get_type_name(var.type)
                     if param_idx >= len(target.parameter_vars):
                         continue
                     target.parameter_vars[param_idx].type = var.type
-                    target.parameter_vars[param_idx].name = types_to_propagate[type_name]
+                    if type_name in types_to_propagate:
+                        target.parameter_vars[param_idx].name = types_to_propagate[type_name]
                     if target not in func_queue:
                         func_queue.append(target)
                     updates = True
@@ -54,9 +59,8 @@ def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, fu
             if not isinstance(target, Constant):
                 continue
 
-            type_name = get_type_name(var.type.target)
-            log_info(f"Propagating {type_name} pointer to data variable at {hex(target.constant)}")
-            bv.define_user_data_var(target.constant, var.type, types_to_propagate[type_name])
+            type_name = get_type_name(var.type)
+            bv.define_user_data_var(target.constant, var.type, types_to_propagate.get(type_name))
             updates = True
         elif isinstance(instr, HighLevelILDerefFieldSsa):
             # Dereferencing field, see if it is a field for a type we want to propagate
@@ -87,7 +91,8 @@ def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, fu
                     continue
 
                 log_info(f"Propagating {expr_type.target.registered_name.name} pointer to data variable at {hex(target.constant)}")
-                bv.define_user_data_var(target.constant, expr_type, types_to_propagate[expr_type.target.registered_name.name])
+                bv.define_user_data_var(target.constant, expr_type,
+                                        types_to_propagate[expr_type.target.registered_name.name])
                 updates = True
                 continue
             else:
@@ -98,6 +103,7 @@ def propagate_variable_uses(bv: BinaryView, func: Function, var: SSAVariable, fu
             updates = True
 
     return updates
+
 
 def propagate_system_table_pointers(bv: BinaryView, task: BackgroundTask):
     # Add entry function to the list of functions in which to propagate.
@@ -120,12 +126,17 @@ def propagate_system_table_pointers(bv: BinaryView, task: BackgroundTask):
         updates = False
         for param_idx in range(len(parameter_vars)):
             param = parameter_vars[param_idx]
-            if not isinstance(param.type, PointerType):
+
+            propagate = False
+            if isinstance(param.type, PointerType):
+                if isinstance(param.type.target, NamedTypeReferenceType):
+                    propagate = True
+            elif isinstance(param.type, NamedTypeReferenceType):
+                if isinstance(param.type.target(bv), PointerType):
+                    propagate = True
+            if not propagate:
                 continue
-            if not isinstance(param.type.target, NamedTypeReferenceType):
-                continue
-            if param.type.target.name not in types_to_propagate.keys():
-                continue
+
             updates |= propagate_variable_uses(bv, func, SSAVariable(param, 0), func_queue)
 
         if updates:


### PR DESCRIPTION
Made two changes in this pr, 
1. Propagate more types, not only types in the pre-defined dictionary but all PointerType and NamedReferenceType. Since We have full confidence in the `entry_function`'s type, these type propagations should be correct.
2. Added an `EFI_GUID` DataRenderer class for better readability.